### PR TITLE
[feat] 본인인증 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package dev.woori.wooriBank.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(redisConnectionFactory());
+
+        // Key: 문자열
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // Value: JSON 형태로 저장하고 싶으면 Jackson 사용
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
@@ -2,6 +2,8 @@ package dev.woori.wooriBank.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import dev.woori.wooriBank.domain.auth.dto.AuthSession;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -38,7 +40,10 @@ public class RedisConfig {
         // NON_FINAL: final이 아닌 모든 클래스에 대해 타입 정보 포함
         // JsonTypeInfo.As.PROPERTY: JSON에 타입 정보 삽입
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.activateDefaultTyping(instance, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        var ptv = BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(AuthSession.class) // AuthSession 클래스에 대해서만 역직렬화 허용
+                                .build();
+        objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
         template.setConnectionFactory(redisConnectionFactory());
 

--- a/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package dev.woori.wooriBank.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +11,8 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import static com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator.instance;
 
 @Configuration
 @EnableCaching
@@ -27,15 +31,22 @@ public class RedisConfig {
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate() {
+        // 형식 설정: key = String, value = object
         RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        // 직렬화(객체->json) 시 클래스 타입 정보를 JSON에 포함시키도록 설정 => 안전하게 역직렬화(json->객체) 가능
+        // NON_FINAL: final이 아닌 모든 클래스에 대해 타입 정보 포함
+        // JsonTypeInfo.As.PROPERTY: JSON에 타입 정보 삽입
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.activateDefaultTyping(instance, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
         template.setConnectionFactory(redisConnectionFactory());
 
         // Key: 문자열
         template.setKeySerializer(new StringRedisSerializer());
 
-        // Value: JSON 형태로 저장하고 싶으면 Jackson 사용
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        // Value: JSON 형태로 저장
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
 
         return template;
     }

--- a/src/main/java/dev/woori/wooriBank/config/filter/AppKeySecretFilter.java
+++ b/src/main/java/dev/woori/wooriBank/config/filter/AppKeySecretFilter.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -21,6 +22,7 @@ import java.io.IOException;
 public class AppKeySecretFilter extends OncePerRequestFilter {
 
     private final BankClientAppRepository bankClientAppRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -28,7 +30,7 @@ public class AppKeySecretFilter extends OncePerRequestFilter {
 
         // 토큰 발급 요청인지 확인 - 아니면 다음 필터로 넘어감
         String path = request.getRequestURI();
-        if (!path.equals("/auth/token")) {
+        if (!path.startsWith("/auth/token")) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -52,7 +54,7 @@ public class AppKeySecretFilter extends OncePerRequestFilter {
 
         // DB에서 검증
         BankClientApp clientApp = bankClientAppRepository.findByAppKey(appKey).orElse(null);
-        if(clientApp == null || !clientApp.getSecretKey().equals(secretKey)) {
+        if(clientApp == null || !passwordEncoder.matches(secretKey, clientApp.getSecretKey())) {
             log.warn("[Unauthorized] {} {} - {}", request.getMethod(), request.getRequestURI(),
                     "appKey 혹은 secretKey가 유효하지 않습니다.");
 

--- a/src/main/java/dev/woori/wooriBank/config/filter/JwtFilter.java
+++ b/src/main/java/dev/woori/wooriBank/config/filter/JwtFilter.java
@@ -1,12 +1,16 @@
 package dev.woori.wooriBank.config.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.woori.wooriBank.config.exception.CommonException;
 import dev.woori.wooriBank.config.jwt.JwtInfo;
 import dev.woori.wooriBank.config.jwt.JwtValidator;
+import dev.woori.wooriBank.config.response.BaseResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -17,12 +21,14 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtValidator jwtValidator;
     private final String BEARER = "Bearer ";
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -30,19 +36,32 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 헤더에서 키값 가져오기
         String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.debug("Authorization Header is present: {}", accessToken != null && accessToken.startsWith(BEARER));
 
-        if (accessToken != null && accessToken.startsWith(BEARER)) {
-            String token = accessToken.substring(BEARER.length()); // 순수 토큰값만 가져오기
-            JwtInfo jwtInfo = jwtValidator.parseToken(token);
+        try{
+            if (accessToken != null && accessToken.startsWith(BEARER)) {
+                String token = accessToken.substring(BEARER.length()); // 순수 토큰값만 가져오기
 
-            // Authentication 객체 생성
-            UsernamePasswordAuthenticationToken auth =
-                    new UsernamePasswordAuthenticationToken(jwtInfo.username(), null,
-                            List.of(new SimpleGrantedAuthority(jwtInfo.role().name())));
+                JwtInfo jwtInfo = jwtValidator.parseToken(token);
 
-            SecurityContextHolder.getContext().setAuthentication(auth);
+                // Authentication 객체 생성
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(jwtInfo.username(), null,
+                                List.of(new SimpleGrantedAuthority(jwtInfo.role().name())));
+
+                SecurityContextHolder.getContext().setAuthentication(auth);
+                log.debug("Authentication after JWT filter = {}",
+                        SecurityContextHolder.getContext().getAuthentication());
+            }
+
+            filterChain.doFilter(request, response);
+        }catch (CommonException e){
+            log.warn("{} - {}", e.getErrorCode(), e.getMessage());
+            response.setStatus(e.getErrorCode().getStatus().value());
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(
+                    BaseResponse.of(e.getErrorCode())
+            ));
         }
-
-        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/dev/woori/wooriBank/config/filter/LoggingFilter.java
+++ b/src/main/java/dev/woori/wooriBank/config/filter/LoggingFilter.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
 
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {

--- a/src/main/java/dev/woori/wooriBank/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,13 @@
+package dev.woori.wooriBank.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public org.springframework.security.crypto.password.PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/dev/woori/wooriBank/config/security/SecurityConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/security/SecurityConfig.java
@@ -69,9 +69,4 @@ public class SecurityConfig {
                 .build();
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
@@ -7,15 +7,11 @@ import dev.woori.wooriBank.domain.auth.dto.AuthReqDto;
 import dev.woori.wooriBank.domain.auth.dto.AuthVerifyReqDto;
 import dev.woori.wooriBank.domain.auth.dto.RefreshReqDto;
 import dev.woori.wooriBank.domain.auth.dto.TokenReqDto;
-import dev.woori.wooriBank.domain.auth.entity.BankClientApp;
 import dev.woori.wooriBank.domain.auth.service.AuthService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j

--- a/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
@@ -3,13 +3,19 @@ package dev.woori.wooriBank.domain.auth.controller;
 import dev.woori.wooriBank.config.response.ApiResponse;
 import dev.woori.wooriBank.config.response.BaseResponse;
 import dev.woori.wooriBank.config.response.SuccessCode;
+import dev.woori.wooriBank.domain.auth.dto.AuthReqDto;
+import dev.woori.wooriBank.domain.auth.dto.AuthVerifyReqDto;
 import dev.woori.wooriBank.domain.auth.dto.RefreshReqDto;
+import dev.woori.wooriBank.domain.auth.dto.TokenReqDto;
 import dev.woori.wooriBank.domain.auth.entity.BankClientApp;
 import dev.woori.wooriBank.domain.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -21,13 +27,28 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/token")
-    public ResponseEntity<BaseResponse<?>> issueToken(HttpServletRequest request){
-        BankClientApp clientApp = (BankClientApp)request.getAttribute("clientApp");
-        return ApiResponse.success(SuccessCode.OK, authService.issueToken(clientApp.getName()));
+    public ResponseEntity<BaseResponse<?>> issueToken(@RequestBody TokenReqDto request){
+        return ApiResponse.success(SuccessCode.OK, authService.issueToken(request.userId()));
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponse<?>> refresh(@RequestBody RefreshReqDto refreshToken) {
         return ApiResponse.success(SuccessCode.OK, authService.refresh(refreshToken));
+    }
+
+    // 본인인증 정보를 입력하면 인증번호를 발송해준다고 가정
+    // 서버에서는 ok 응답만 보내줌
+    @PostMapping("/request")
+    public ResponseEntity<BaseResponse<?>> request(@AuthenticationPrincipal String username,
+                                                   @RequestBody AuthReqDto authReqDto){
+        authService.request(username, authReqDto);
+        return ApiResponse.success(SuccessCode.OK);
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<BaseResponse<?>> verify(@AuthenticationPrincipal String username,
+                                                  @RequestBody AuthVerifyReqDto request){
+        authService.verify(username, request);
+        return ApiResponse.success(SuccessCode.OK);
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthReqDto.java
@@ -1,0 +1,8 @@
+package dev.woori.wooriBank.domain.auth.dto;
+
+public record AuthReqDto(
+        String name,
+        String phone,
+        String birth
+) {
+}

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthSession.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthSession.java
@@ -13,6 +13,7 @@ public class AuthSession{
     private String phone; // 사용자 전화번호
     private String birth; // 사용자 생년월일
     private String authCode; // 인증번호
+    private int failedAttempts; // 인증번호 실패 횟수
     private boolean verified; // 검증 여부
 
     // 이후 필요한 필드 구현하면서 추가하기

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthSession.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthSession.java
@@ -1,0 +1,19 @@
+package dev.woori.wooriBank.domain.auth.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthSession{
+    private String id; // jwt 토큰값을 기반으로 한 id
+    private String name; // 사용자 이름
+    private String phone; // 사용자 전화번호
+    private String birth; // 사용자 생년월일
+    private String authCode; // 인증번호
+    private boolean verified; // 검증 여부
+
+    // 이후 필요한 필드 구현하면서 추가하기
+}

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthVerifyReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthVerifyReqDto.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriBank.domain.auth.dto;
+
+public record AuthVerifyReqDto(
+        String authCode
+) {
+}

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/TokenReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/TokenReqDto.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriBank.domain.auth.dto;
+
+public record TokenReqDto(
+    String userId
+) {
+}

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
@@ -21,7 +21,7 @@ public class AuthStoreRedis {
     // id에 매핑된 객체를 불러옴
     public AuthSession get(String sessionId) {
         Object obj = redisTemplate.opsForValue().get(sessionId);
-        return (AuthSession) obj;
+        return (obj instanceof AuthSession) ? (AuthSession) obj : null;
     }
 
     public void delete(String sessionId) {

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
@@ -2,6 +2,7 @@ package dev.woori.wooriBank.domain.auth.entity;
 
 import dev.woori.wooriBank.domain.auth.dto.AuthSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -12,10 +13,12 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class AuthStoreRedis {
     private final RedisTemplate<String, Object> redisTemplate;
+    @Value("${auth.session.ttl}")
+    private long sessionTtl;
 
     // 세션 id를 키값으로 session 객체를 저장
     public void save(String sessionId, AuthSession session) {
-        redisTemplate.opsForValue().set(sessionId, session, 5, TimeUnit.MINUTES); // 만료 5분
+        redisTemplate.opsForValue().set(sessionId, session, sessionTtl, TimeUnit.SECONDS);
     }
 
     // id에 매핑된 객체를 불러옴

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
@@ -1,0 +1,30 @@
+package dev.woori.wooriBank.domain.auth.entity;
+
+import dev.woori.wooriBank.domain.auth.dto.AuthSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+// redis 저장소
+@Component
+@RequiredArgsConstructor
+public class AuthStoreRedis {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 세션 id를 키값으로 session 객체를 저장
+    public void save(String sessionId, AuthSession session) {
+        redisTemplate.opsForValue().set(sessionId, session, 5, TimeUnit.MINUTES); // 만료 5분
+    }
+
+    // id에 매핑된 객체를 불러옴
+    public AuthSession get(String sessionId) {
+        Object obj = redisTemplate.opsForValue().get(sessionId);
+        return (AuthSession) obj;
+    }
+
+    public void delete(String sessionId) {
+        redisTemplate.delete(sessionId);
+    }
+}

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -16,8 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
 import java.time.Instant;
-import java.util.Random;
 
 @Slf4j
 @Service
@@ -66,9 +66,14 @@ public class AuthService {
         return generateAndSaveToken(username, role);
     }
 
+    /**
+     * 사용자의 요청을 받아 개인정보를 임시로 저장하고 인증번호를 생성합니다.
+     * @param userId 사용자 id (혹은 redis 키값 / sessionId 같은 개념)
+     * @param request 사용자의 개인정보가 담긴 dto
+     */
     public void request(String userId, AuthReqDto request){
         // 인증번호 생성 - 랜덤 6자리
-        String authCode = String.format("%06d", new Random().nextInt(1000000));
+        String authCode = String.format("%06d", new SecureRandom().nextInt(1000000));
 
         // 사용자 정보 임시저장
         AuthSession session = AuthSession.builder()
@@ -83,9 +88,14 @@ public class AuthService {
         redis.save(userId, session);
 
         // 테스트용: 만들어진 코드를 콘솔에서 확인할 수 있도록 설정
-        log.info("authCode: {}", authCode);
+        log.debug("authCode: {}", authCode);
     }
 
+    /**
+     * 입력받은 인증번호가 올바른지 검증합니다.
+     * @param userId 사용자 id (혹은 redis 키값 / sessionId 같은 개념)
+     * @param request 사용자가 입력한 인증번호
+     */
     public void verify(String userId, AuthVerifyReqDto request){
         // 입력받은 인증번호와 저장된 인증번호 비교
         AuthSession session = redis.get(userId);

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -30,6 +30,7 @@ public class AuthService {
     private final JwtValidator jwtValidator;
     private final RefreshTokenPort refreshTokenRepository;
     private final AuthStoreRedis redis;
+    private static final SecureRandom random = new SecureRandom();
 
     /**
      * name에 따른 token을 발급합니다.
@@ -73,7 +74,7 @@ public class AuthService {
      */
     public void request(String userId, AuthReqDto request){
         // 인증번호 생성 - 랜덤 6자리
-        String authCode = String.format("%06d", new SecureRandom().nextInt(1000000));
+        String authCode = String.format("%06d", random.nextInt(1000000));
 
         // 사용자 정보 임시저장
         AuthSession session = AuthSession.builder()
@@ -82,6 +83,7 @@ public class AuthService {
                 .phone(request.phone())
                 .birth(request.birth())
                 .authCode(authCode)
+                .failedAttempts(0)
                 .verified(false)
                 .build();
 
@@ -106,6 +108,12 @@ public class AuthService {
         }
 
         if(!request.authCode().equals(session.getAuthCode())){
+            // 일정 횟수 이상 실패했을 경우
+            if(session.getFailedAttempts() >= 5){
+                redis.delete(userId); // 세션 삭제
+                throw new CommonException(ErrorCode.FORBIDDEN, "인증번호 검증에 실패했습니다. 인증번호를 다시 발급해 주세요.");
+            }
+            session.setFailedAttempts(session.getFailedAttempts() + 1);
             throw new CommonException(ErrorCode.UNAUTHORIZED, "인증번호가 일치하지 않습니다.");
         }
 

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import dev.woori.wooriBank.domain.auth.port.RefreshTokenPort;
 import dev.woori.wooriBank.domain.auth.entity.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,8 @@ public class AuthService {
     private final RefreshTokenPort refreshTokenRepository;
     private final AuthStoreRedis redis;
     private static final SecureRandom random = new SecureRandom();
+    @Value("${auth.verification.max-attempts}")
+    private int maxAttempts;
 
     /**
      * name에 따른 token을 발급합니다.
@@ -109,11 +112,12 @@ public class AuthService {
 
         if(!request.authCode().equals(session.getAuthCode())){
             // 일정 횟수 이상 실패했을 경우
-            if(session.getFailedAttempts() >= 5){
+            if(session.getFailedAttempts() >= maxAttempts){
                 redis.delete(userId); // 세션 삭제
                 throw new CommonException(ErrorCode.FORBIDDEN, "인증번호 검증에 실패했습니다. 인증번호를 다시 발급해 주세요.");
             }
             session.setFailedAttempts(session.getFailedAttempts() + 1);
+            redis.save(userId, session); // 실패 횟수 업데이트
             throw new CommonException(ErrorCode.UNAUTHORIZED, "인증번호가 일치하지 않습니다.");
         }
 

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -5,8 +5,8 @@ import dev.woori.wooriBank.config.exception.ErrorCode;
 import dev.woori.wooriBank.config.jwt.JwtInfo;
 import dev.woori.wooriBank.config.jwt.JwtValidator;
 import dev.woori.wooriBank.config.security.Encoder;
-import dev.woori.wooriBank.domain.auth.dto.TokenResDto;
-import dev.woori.wooriBank.domain.auth.dto.RefreshReqDto;
+import dev.woori.wooriBank.domain.auth.dto.*;
+import dev.woori.wooriBank.domain.auth.entity.AuthStoreRedis;
 import dev.woori.wooriBank.domain.auth.entity.RefreshToken;
 import dev.woori.wooriBank.domain.auth.jwt.JwtIssuer;
 import dev.woori.wooriBank.domain.auth.port.RefreshTokenPort;
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Random;
 
 @Slf4j
 @Service
@@ -28,6 +29,7 @@ public class AuthService {
     private final JwtIssuer jwtIssuer;
     private final JwtValidator jwtValidator;
     private final RefreshTokenPort refreshTokenRepository;
+    private final AuthStoreRedis redis;
 
     /**
      * name에 따른 token을 발급합니다.
@@ -62,6 +64,44 @@ public class AuthService {
 
         // 검증 끝나면 access token/refresh token 생성해서 return
         return generateAndSaveToken(username, role);
+    }
+
+    public void request(String userId, AuthReqDto request){
+        // 인증번호 생성 - 랜덤 6자리
+        String authCode = String.format("%06d", new Random().nextInt(1000000));
+
+        // 사용자 정보 임시저장
+        AuthSession session = AuthSession.builder()
+                .id(userId)
+                .name(request.name())
+                .phone(request.phone())
+                .birth(request.birth())
+                .authCode(authCode)
+                .verified(false)
+                .build();
+
+        redis.save(userId, session);
+
+        // 테스트용: 만들어진 코드를 콘솔에서 확인할 수 있도록 설정
+        log.info("authCode: {}", authCode);
+    }
+
+    public void verify(String userId, AuthVerifyReqDto request){
+        // 입력받은 인증번호와 저장된 인증번호 비교
+        AuthSession session = redis.get(userId);
+
+        // 시간만료 등의 이유로 데이터가 사라진 경우
+        if(session == null){
+            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND, "데이터를 찾을 수 없습니다.");
+        }
+
+        if(!request.authCode().equals(session.getAuthCode())){
+            throw new CommonException(ErrorCode.UNAUTHORIZED, "인증번호가 일치하지 않습니다.");
+        }
+
+        // 인증에 성공하면 verified 상태로 전환
+        session.setVerified(true);
+        redis.save(userId, session);
     }
 
     public TokenResDto generateAndSaveToken(String username, Role role){


### PR DESCRIPTION
## ✅ 연관된 이슈
#7

## 📝 작업 내용
- 간단한 redis 적용
- 본인인증 요청 (서버 입장에서는 인증번호 제공) api 구현
- 본인인증 검증 api 구현
- 우리 서버에서 요청할 경우 access token 발급하는 api 구현(appKey - secretKey 인증방식)

## 🖼️ 스크린샷 (선택)
<img width="1016" height="771" alt="image" src="https://github.com/user-attachments/assets/282f62b0-cd8b-4b93-8a14-5ba5c1a54f2c" />

access token 발급
(헤더에 appKey / secretKey 설정 필요)

---

<img width="909" height="573" alt="image" src="https://github.com/user-attachments/assets/9f78f8bc-3f7a-466e-9271-568f42deb7c6" />

인증번호 발급 api
개인정보를 입력하면 access token에 담긴 id를 key로 redis에 정보를 임시로 저장해둠
이후 인증번호도 저장

---

<img width="925" height="597" alt="image" src="https://github.com/user-attachments/assets/4d59d32c-ea8d-4fbf-8824-8559b42ecd27" />

인증번호 검증 api - 성공

---

<img width="888" height="616" alt="image" src="https://github.com/user-attachments/assets/6fbae744-2be5-427d-af84-fb98ee923d93" />

인증번호 검증 api - 실패


