### PR TITLE
[feat] 계좌개설 과정 관련 api 수정

### DIFF
--- a/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -24,9 +25,16 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.database}")
+    private int database;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory(){
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        configuration.setDatabase(database);
+        return new LettuceConnectionFactory(configuration);
     }
 
     @Bean
@@ -40,7 +48,7 @@ public class RedisConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         var ptv = BasicPolymorphicTypeValidator.builder()
                         .allowIfBaseType(AuthSession.class) // AuthSession 클래스에 대해서만 역직렬화 허용
-                                .build();
+                        .build();
         objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
         template.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
+++ b/src/main/java/dev/woori/wooriBank/config/RedisConfig.java
@@ -38,18 +38,18 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(ObjectMapper objectMapper) {
         // 형식 설정: key = String, value = object
         RedisTemplate<String, Object> template = new RedisTemplate<>();
 
         // 직렬화(객체->json) 시 클래스 타입 정보를 JSON에 포함시키도록 설정 => 안전하게 역직렬화(json->객체) 가능
         // NON_FINAL: final이 아닌 모든 클래스에 대해 타입 정보 포함
         // JsonTypeInfo.As.PROPERTY: JSON에 타입 정보 삽입
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper customObjectMapper = objectMapper.copy();
         var ptv = BasicPolymorphicTypeValidator.builder()
                         .allowIfBaseType(AuthSession.class) // AuthSession 클래스에 대해서만 역직렬화 허용
                         .build();
-        objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        customObjectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
         template.setConnectionFactory(redisConnectionFactory());
 
@@ -57,7 +57,7 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
 
         // Value: JSON 형태로 저장
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(customObjectMapper));
 
         return template;
     }

--- a/src/main/java/dev/woori/wooriBank/config/filter/AppKeySecretFilter.java
+++ b/src/main/java/dev/woori/wooriBank/config/filter/AppKeySecretFilter.java
@@ -34,7 +34,6 @@ public class AppKeySecretFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 토큰 발급 요청인 경우
         // 헤더에서 appKey와 secretKey값을 꺼내옴
         String appKey = request.getHeader("appKey");
         String secretKey = request.getHeader("secretKey");
@@ -67,7 +66,7 @@ public class AppKeySecretFilter extends OncePerRequestFilter {
         // TODO: payload secretKey로 검증하기
 
         // 검증이 끝나면 clientApp을 attribute로 설정
-        request.setAttribute("clientApp", clientApp);
+        request.setAttribute("clientApp", clientApp.getClientId());
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/dev/woori/wooriBank/config/filter/AppKeySecretFilter.java
+++ b/src/main/java/dev/woori/wooriBank/config/filter/AppKeySecretFilter.java
@@ -28,9 +28,8 @@ public class AppKeySecretFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        // 토큰 발급 요청인지 확인 - 아니면 다음 필터로 넘어감
         String path = request.getRequestURI();
-        if (!path.startsWith("/auth/token")) {
+        if (!path.startsWith("/account")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/dev/woori/wooriBank/domain/account/controller/AccountController.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/controller/AccountController.java
@@ -4,15 +4,11 @@ import dev.woori.wooriBank.config.response.ApiResponse;
 import dev.woori.wooriBank.config.response.BaseResponse;
 import dev.woori.wooriBank.config.response.SuccessCode;
 import dev.woori.wooriBank.domain.account.dto.AccountLookupReqDto;
-import dev.woori.wooriBank.domain.account.dto.TidReqDto;
 import dev.woori.wooriBank.domain.account.service.AccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/account")
@@ -22,8 +18,8 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping("/tid")
-    public ResponseEntity<BaseResponse<?>> getTid(@Valid @RequestBody TidReqDto request){
-        return ApiResponse.success(SuccessCode.OK, accountService.getTid(request));
+    public ResponseEntity<BaseResponse<?>> getTid(@RequestAttribute("clientApp") String clientId){
+        return ApiResponse.success(SuccessCode.OK, accountService.getTid(clientId));
     }
 
     @PostMapping("/lookup")

--- a/src/main/java/dev/woori/wooriBank/domain/account/controller/AccountController.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/controller/AccountController.java
@@ -4,6 +4,7 @@ import dev.woori.wooriBank.config.response.ApiResponse;
 import dev.woori.wooriBank.config.response.BaseResponse;
 import dev.woori.wooriBank.config.response.SuccessCode;
 import dev.woori.wooriBank.domain.account.dto.AccountLookupReqDto;
+import dev.woori.wooriBank.domain.account.dto.TidReqDto;
 import dev.woori.wooriBank.domain.account.service.AccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
     private final AccountService accountService;
+
+    @PostMapping("/tid")
+    public ResponseEntity<BaseResponse<?>> getTid(@Valid @RequestBody TidReqDto request){
+        return ApiResponse.success(SuccessCode.OK, accountService.getTid(request));
+    }
 
     @PostMapping("/lookup")
     public ResponseEntity<BaseResponse<?>> accountLookup(@Valid @RequestBody AccountLookupReqDto request){

--- a/src/main/java/dev/woori/wooriBank/domain/account/dto/TidReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/dto/TidReqDto.java
@@ -1,8 +1,0 @@
-package dev.woori.wooriBank.domain.account.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record TidReqDto(
-        @NotBlank String clientId
-) {
-}

--- a/src/main/java/dev/woori/wooriBank/domain/account/dto/TidReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/dto/TidReqDto.java
@@ -2,7 +2,7 @@ package dev.woori.wooriBank.domain.account.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record AccountLookupReqDto(
-        @NotBlank String tid
+public record TidReqDto(
+        @NotBlank String clientId
 ) {
 }

--- a/src/main/java/dev/woori/wooriBank/domain/account/dto/TidResDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/dto/TidResDto.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriBank.domain.account.dto;
+
+public record TidResDto(
+        String tid
+) {
+}

--- a/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
@@ -7,7 +7,6 @@ import dev.woori.wooriBank.domain.account.dto.AccountLookupResDto;
 import dev.woori.wooriBank.domain.account.dto.TidResDto;
 import dev.woori.wooriBank.domain.auth.entity.AuthSession;
 import dev.woori.wooriBank.domain.auth.entity.AuthStoreRedis;
-import dev.woori.wooriBank.domain.auth.repository.BankClientAppRepository;
 import dev.woori.wooriBank.domain.util.ValidationUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
@@ -19,14 +19,9 @@ import java.util.UUID;
 public class AccountService {
 
     private final AuthStoreRedis redis;
-    private final BankClientAppRepository bankClientAppRepository;
     private final ValidationUtil validationUtil;
 
     public TidResDto getTid(String clientId) {
-        // clientId 검증
-        if(!bankClientAppRepository.existsByClientId(clientId)){
-            throw new CommonException(ErrorCode.FORBIDDEN);
-        }
 
         // 랜덤 tid 생성 및 저장
         String tid = UUID.randomUUID().toString();

--- a/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
@@ -4,7 +4,6 @@ import dev.woori.wooriBank.config.exception.CommonException;
 import dev.woori.wooriBank.config.exception.ErrorCode;
 import dev.woori.wooriBank.domain.account.dto.AccountLookupReqDto;
 import dev.woori.wooriBank.domain.account.dto.AccountLookupResDto;
-import dev.woori.wooriBank.domain.account.dto.TidReqDto;
 import dev.woori.wooriBank.domain.account.dto.TidResDto;
 import dev.woori.wooriBank.domain.auth.entity.AuthSession;
 import dev.woori.wooriBank.domain.auth.entity.AuthStoreRedis;
@@ -23,9 +22,9 @@ public class AccountService {
     private final BankClientAppRepository bankClientAppRepository;
     private final ValidationUtil validationUtil;
 
-    public TidResDto getTid(TidReqDto tidReqDto) {
+    public TidResDto getTid(String clientId) {
         // clientId 검증
-        if(!bankClientAppRepository.existsByClientId(tidReqDto.clientId())){
+        if(!bankClientAppRepository.existsByClientId(clientId)){
             throw new CommonException(ErrorCode.FORBIDDEN);
         }
 
@@ -34,7 +33,7 @@ public class AccountService {
 
         AuthSession session = AuthSession.builder()
                 .tid(tid)
-                .clientId(tidReqDto.clientId())
+                .clientId(clientId)
                 .build();
 
         // redis 저장

--- a/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
@@ -9,6 +9,7 @@ import dev.woori.wooriBank.domain.account.dto.TidResDto;
 import dev.woori.wooriBank.domain.auth.entity.AuthSession;
 import dev.woori.wooriBank.domain.auth.entity.AuthStoreRedis;
 import dev.woori.wooriBank.domain.auth.repository.BankClientAppRepository;
+import dev.woori.wooriBank.domain.util.ValidationUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ public class AccountService {
 
     private final AuthStoreRedis redis;
     private final BankClientAppRepository bankClientAppRepository;
+    private final ValidationUtil validationUtil;
 
     public TidResDto getTid(TidReqDto tidReqDto) {
         // clientId 검증
@@ -41,21 +43,12 @@ public class AccountService {
     }
 
     public AccountLookupResDto accountLookup(AccountLookupReqDto request){
-        AuthSession session = getSessionOrThrow(request.tid());
+        AuthSession session = validationUtil.getSessionOrThrow(request.tid());
 
         // 검증 성공 후 정보 삭제
         redis.delete(request.tid());
 
         // 이름 & 계좌번호 return
         return new AccountLookupResDto(session.getName(), session.getAccountNum());
-    }
-
-    private AuthSession getSessionOrThrow(String userId) {
-        AuthSession session = redis.get(userId);
-        if (session == null) {
-            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND,
-                    "세션이 만료되었습니다. 처음부터 다시 시작해주세요.");
-        }
-        return session;
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
@@ -4,37 +4,58 @@ import dev.woori.wooriBank.config.exception.CommonException;
 import dev.woori.wooriBank.config.exception.ErrorCode;
 import dev.woori.wooriBank.domain.account.dto.AccountLookupReqDto;
 import dev.woori.wooriBank.domain.account.dto.AccountLookupResDto;
+import dev.woori.wooriBank.domain.account.dto.TidReqDto;
+import dev.woori.wooriBank.domain.account.dto.TidResDto;
 import dev.woori.wooriBank.domain.auth.entity.AuthSession;
 import dev.woori.wooriBank.domain.auth.entity.AuthStoreRedis;
+import dev.woori.wooriBank.domain.auth.repository.BankClientAppRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
     private final AuthStoreRedis redis;
+    private final BankClientAppRepository bankClientAppRepository;
+
+    public TidResDto getTid(TidReqDto tidReqDto) {
+        // clientId 검증
+        if(!bankClientAppRepository.existsByClientId(tidReqDto.clientId())){
+            throw new CommonException(ErrorCode.FORBIDDEN);
+        }
+
+        // 랜덤 tid 생성 및 저장
+        String tid = UUID.randomUUID().toString();
+
+        AuthSession session = AuthSession.builder()
+                .clientId(tidReqDto.clientId())
+                .build();
+
+        // redis 저장
+        redis.save(tid, session);
+
+        return new TidResDto(tid);
+    }
 
     public AccountLookupResDto accountLookup(AccountLookupReqDto request){
-        String id = request.id();
-        String code = request.code();
-
-        // 코드와 redis 내부 저장소에 저장된 코드를 비교하기
-        AuthSession session = redis.get(id);
-
-        // 시간만료 등의 이유로 데이터가 사라진 경우
-        if(session == null){
-            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND, "데이터를 찾을 수 없습니다.");
-        }
-        // 코드 검증이 실패할 경우
-        if(!code.equals(session.getCode())){
-            throw new CommonException(ErrorCode.UNAUTHORIZED, "인증 코드 오류");
-        }
+        AuthSession session = getSessionOrThrow(request.tid());
 
         // 검증 성공 후 정보 삭제
-        redis.delete(id);
+        redis.delete(request.tid());
 
         // 이름 & 계좌번호 return
         return new AccountLookupResDto(session.getName(), session.getAccountNum());
+    }
+
+    private AuthSession getSessionOrThrow(String userId) {
+        AuthSession session = redis.get(userId);
+        if (session == null) {
+            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND,
+                    "세션이 만료되었습니다. 처음부터 다시 시작해주세요.");
+        }
+        return session;
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/account/service/AccountService.java
@@ -33,6 +33,7 @@ public class AccountService {
         String tid = UUID.randomUUID().toString();
 
         AuthSession session = AuthSession.builder()
+                .tid(tid)
                 .clientId(tidReqDto.clientId())
                 .build();
 
@@ -44,6 +45,11 @@ public class AccountService {
 
     public AccountLookupResDto accountLookup(AccountLookupReqDto request){
         AuthSession session = validationUtil.getSessionOrThrow(request.tid());
+
+        // 인증 여부 확인
+        if (!session.isVerified()) {
+            throw new CommonException(ErrorCode.FORBIDDEN, "본인인증이 완료되지 않았습니다.");
+        }
 
         // 검증 성공 후 정보 삭제
         redis.delete(request.tid());

--- a/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
@@ -35,16 +35,14 @@ public class AuthController {
     // 본인인증 정보를 입력하면 인증번호를 발송해준다고 가정
     // 서버에서는 ok 응답만 보내줌
     @PostMapping("/request")
-    public ResponseEntity<BaseResponse<?>> request(@AuthenticationPrincipal String username,
-                                                   @RequestBody AuthReqDto authReqDto){
-        authService.request(username, authReqDto);
+    public ResponseEntity<BaseResponse<?>> request(@RequestBody AuthReqDto authReqDto){
+        authService.request(authReqDto);
         return ApiResponse.success(SuccessCode.OK);
     }
 
     @PostMapping("/verify")
-    public ResponseEntity<BaseResponse<?>> verify(@AuthenticationPrincipal String username,
-                                                  @RequestBody AuthVerifyReqDto request){
-        authService.verify(username, request);
+    public ResponseEntity<BaseResponse<?>> verify(@RequestBody AuthVerifyReqDto request){
+        authService.verify(request);
         return ApiResponse.success(SuccessCode.OK);
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/controller/AuthController.java
@@ -3,10 +3,7 @@ package dev.woori.wooriBank.domain.auth.controller;
 import dev.woori.wooriBank.config.response.ApiResponse;
 import dev.woori.wooriBank.config.response.BaseResponse;
 import dev.woori.wooriBank.config.response.SuccessCode;
-import dev.woori.wooriBank.domain.auth.dto.AuthReqDto;
-import dev.woori.wooriBank.domain.auth.dto.AuthVerifyReqDto;
-import dev.woori.wooriBank.domain.auth.dto.RefreshReqDto;
-import dev.woori.wooriBank.domain.auth.dto.TokenReqDto;
+import dev.woori.wooriBank.domain.auth.dto.*;
 import dev.woori.wooriBank.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +40,12 @@ public class AuthController {
     @PostMapping("/verify")
     public ResponseEntity<BaseResponse<?>> verify(@RequestBody AuthVerifyReqDto request){
         authService.verify(request);
+        return ApiResponse.success(SuccessCode.OK);
+    }
+
+    @PostMapping("/request/resend")
+    public ResponseEntity<BaseResponse<?>> resend(@RequestBody AuthCodeRefreshReqDto request){
+        authService.resendAuthCode(request);
         return ApiResponse.success(SuccessCode.OK);
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthCodeRefreshReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthCodeRefreshReqDto.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriBank.domain.auth.dto;
+
+public record AuthCodeRefreshReqDto(
+        String tid
+) {
+}

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthReqDto.java
@@ -1,6 +1,7 @@
 package dev.woori.wooriBank.domain.auth.dto;
 
 public record AuthReqDto(
+        String tid,
         String name,
         String phone,
         String birth

--- a/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthVerifyReqDto.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/dto/AuthVerifyReqDto.java
@@ -1,6 +1,7 @@
 package dev.woori.wooriBank.domain.auth.dto;
 
 public record AuthVerifyReqDto(
+        String tid,
         String authCode
 ) {
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthSession.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthSession.java
@@ -8,7 +8,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AuthSession{
-    private String id; // jwt 토큰값을 기반으로 한 id
+    private String clientId;
+
     private String name; // 사용자 이름
     private String phone; // 사용자 전화번호
     private String birth; // 사용자 생년월일

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthSession.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthSession.java
@@ -13,8 +13,10 @@ public class AuthSession{
     private String name; // 사용자 이름
     private String phone; // 사용자 전화번호
     private String birth; // 사용자 생년월일
+
     private String authCode; // 인증번호
     private int failedAttempts; // 인증번호 실패 횟수
+    private int resendAttempts = 0; // 인증번호 재발송 횟수
     private boolean verified; // 검증 여부
 
     private String accountNum;

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthSession.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthSession.java
@@ -8,6 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AuthSession{
+    private String tid;
     private String clientId;
 
     private String name; // 사용자 이름

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/AuthStoreRedis.java
@@ -23,7 +23,7 @@ public class AuthStoreRedis {
     // id에 매핑된 객체를 불러옴
     public AuthSession get(String sessionId) {
         Object obj = redisTemplate.opsForValue().get(sessionId);
-        return (obj instanceof AuthSession) ? (AuthSession) obj : null;
+        return (obj instanceof AuthSession session) ? session : null;
     }
 
     public void delete(String sessionId) {

--- a/src/main/java/dev/woori/wooriBank/domain/auth/entity/BankClientApp.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/entity/BankClientApp.java
@@ -16,14 +16,17 @@ public class BankClientApp extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "client_id")
+    private String clientId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
     @Column(name = "app_key", nullable = false, unique = true)
     private String appKey;
 
     @Column(name = "secret_key", nullable = false)
     private String secretKey;
-
-    @Column(name = "name", nullable = false)
-    private String name;
 
     @Column(name = "redirect_url")
     private String redirectUrl;

--- a/src/main/java/dev/woori/wooriBank/domain/auth/repository/BankClientAppRepository.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/repository/BankClientAppRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface BankClientAppRepository extends JpaRepository<BankClientApp, Long> {
     Optional<BankClientApp> findByAppKey(String appKey);
+
+    boolean existsByClientId(String clientId);
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/repository/BankClientAppRepository.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/repository/BankClientAppRepository.java
@@ -7,6 +7,4 @@ import java.util.Optional;
 
 public interface BankClientAppRepository extends JpaRepository<BankClientApp, Long> {
     Optional<BankClientApp> findByAppKey(String appKey);
-
-    boolean existsByClientId(String clientId);
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -130,6 +130,7 @@ public class AuthService {
      */
     public void resendAuthCode(AuthCodeRefreshReqDto request){
         AuthSession session = validationUtil.getSessionOrThrow(request.tid());
+        session.setResendAttempts(session.getResendAttempts() + 1);
         issueNewAuthCode(session);
     }
 
@@ -172,7 +173,6 @@ public class AuthService {
 
         session.setFailedAttempts(0);
         session.setVerified(false);
-        session.setResendAttempts(session.getResendAttempts() + 1);
 
         // 테스트용: 만들어진 코드를 콘솔에서 확인할 수 있도록 설정
         log.info("authCode: {}", newCode);

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -89,14 +89,8 @@ public class AuthService {
         session.setBirth(request.birth());
         session.setPhone(request.phone());
         session.setAuthCode(authCode);
-        session.setFailedAttempts(0); // 실패 횟수 초기화
-        session.setVerified(false); // 인증 상태 초기화
-        redis.save(request.tid(), session);
 
-        // 인증번호를 보내준다 가정함
-
-        // 테스트용: 만들어진 코드를 콘솔에서 확인할 수 있도록 설정
-        log.info("authCode: {}", authCode);
+        issueNewAuthCode(session);
     }
 
     /**
@@ -128,6 +122,8 @@ public class AuthService {
 
         // 인증에 성공하면 verified 상태로 전환
         session.setVerified(true);
+        session.setAuthCode(null);
+        session.setFailedAttempts(0);
         redis.save(request.tid(), session);
     }
 
@@ -137,24 +133,10 @@ public class AuthService {
      */
     public void resendAuthCode(AuthCodeRefreshReqDto request){
         AuthSession session = validationUtil.getSessionOrThrow(request.tid());
-
-        // 재발급 시도가 너무 많을 경우
-        if(session.getResendAttempts() >= maxAttempts){
-            redis.delete(request.tid()); // 세션 삭제
-            throw new CommonException(ErrorCode.FORBIDDEN,
-                    "재발송 횟수를 초과했습니다. 처음부터 다시 시도해주세요.");
-        }
-
-        // 새로운 인증번호 발급
-        String newCode = String.format("%06d", random.nextInt(1000000));
-        session.setAuthCode(newCode);
-        session.setFailedAttempts(0);
-        session.setResendAttempts(session.getResendAttempts() + 1);
-
-        redis.save(request.tid(), session);
+        issueNewAuthCode(session);
     }
 
-    public TokenResDto generateAndSaveToken(String username, Role role){
+    private TokenResDto generateAndSaveToken(String username, Role role){
         // jwt 토큰 저장 로직
         String accessToken = jwtIssuer.generateAccessToken(username, role);
         var refreshTokenInfo = jwtIssuer.generateRefreshToken(username, role);
@@ -176,5 +158,27 @@ public class AuthService {
         refreshTokenRepository.save(token);
 
         return new TokenResDto(accessToken, refreshToken);
+    }
+
+    // 인증번호 발급용 메서드
+    private void issueNewAuthCode(AuthSession session){
+        // 재발급 시도가 너무 많을 경우
+        if(session.getResendAttempts() >= maxAttempts){
+            redis.delete(session.getTid()); // 세션 삭제
+            throw new CommonException(ErrorCode.FORBIDDEN,
+                    "재발송 횟수를 초과했습니다. 처음부터 다시 시도해주세요.");
+        }
+
+        // 새로운 인증번호 발급
+        String newCode = String.format("%06d", random.nextInt(1000000));
+        session.setAuthCode(newCode);
+
+        session.setFailedAttempts(0);
+        session.setVerified(false);
+        session.setResendAttempts(session.getResendAttempts() + 1);
+
+        // 테스트용: 만들어진 코드를 콘솔에서 확인할 수 있도록 설정
+        log.info("authCode: {}", newCode);
+        redis.save(session.getTid(), session);
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -72,59 +72,53 @@ public class AuthService {
     }
 
     /**
-     * 사용자의 요청을 받아 개인정보를 임시로 저장하고 인증번호를 생성합니다.
-     * @param userId 사용자 id (혹은 redis 키값 / sessionId 같은 개념)
-     * @param request 사용자의 개인정보가 담긴 dto
+     * 사용자가 입력한 본인인증 정보를 저장하고, 인증번호를 생성합니다.
+     * @param request tid + 사용자가 입력한 개인정보(이름, 생일, 전화번호)
      */
-    public void request(String userId, AuthReqDto request){
+    public void request(AuthReqDto request){
+        // tid 검증
+        AuthSession session = getSessionOrThrow(request.tid());
+
         // 인증번호 생성 - 랜덤 6자리
         String authCode = String.format("%06d", random.nextInt(1000000));
 
-        // 사용자 정보 임시저장
-        AuthSession session = AuthSession.builder()
-                .id(userId)
-                .name(request.name())
-                .phone(request.phone())
-                .birth(request.birth())
-                .authCode(authCode)
-                .failedAttempts(0)
-                .verified(false)
-                .build();
+        // 세션에 임시저장
+        session.setName(request.name());
+        session.setBirth(request.birth());
+        session.setPhone(request.phone());
+        session.setAuthCode(authCode);
+        redis.save(request.tid(), session);
 
-        redis.save(userId, session);
+        // 인증번호를 보내준다 가정함
 
         // 테스트용: 만들어진 코드를 콘솔에서 확인할 수 있도록 설정
-        log.debug("authCode: {}", authCode);
+        log.info("authCode: {}", authCode);
     }
 
     /**
-     * 입력받은 인증번호가 올바른지 검증합니다.
-     * @param userId 사용자 id (혹은 redis 키값 / sessionId 같은 개념)
-     * @param request 사용자가 입력한 인증번호
+     * 사용자가 입력한 인증번호를 검증합니다.
+     * @param request tid + 입력한 인증번호
      */
-    public void verify(String userId, AuthVerifyReqDto request){
-        // 입력받은 인증번호와 저장된 인증번호 비교
-        AuthSession session = redis.get(userId);
-
-        // 시간만료 등의 이유로 데이터가 사라진 경우
-        if(session == null){
-            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND, "데이터를 찾을 수 없습니다.");
-        }
+    public void verify(AuthVerifyReqDto request){
+        // tid 검증
+        AuthSession session = getSessionOrThrow(request.tid());
 
         if(!request.authCode().equals(session.getAuthCode())){
             // 일정 횟수 이상 실패했을 경우
             if(session.getFailedAttempts() >= maxAttempts){
-                redis.delete(userId); // 세션 삭제
+                session.setFailedAttempts(0);
+                redis.save(request.tid(), session);
+                // TODO: 실패한 이후 세션 삭제...?
                 throw new CommonException(ErrorCode.FORBIDDEN, "인증번호 검증에 실패했습니다. 인증번호를 다시 발급해 주세요.");
             }
             session.setFailedAttempts(session.getFailedAttempts() + 1);
-            redis.save(userId, session); // 실패 횟수 업데이트
+            redis.save(request.tid(), session); // 실패 횟수 업데이트
             throw new CommonException(ErrorCode.UNAUTHORIZED, "인증번호가 일치하지 않습니다.");
         }
 
         // 인증에 성공하면 verified 상태로 전환
         session.setVerified(true);
-        redis.save(userId, session);
+        redis.save(request.tid(), session);
     }
 
     public TokenResDto generateAndSaveToken(String username, Role role){
@@ -149,5 +143,14 @@ public class AuthService {
         refreshTokenRepository.save(token);
 
         return new TokenResDto(accessToken, refreshToken);
+    }
+
+    private AuthSession getSessionOrThrow(String tid) {
+        AuthSession session = redis.get(tid);
+        if (session == null) {
+            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND,
+                    "세션이 만료되었습니다. 처음부터 다시 시작해주세요.");
+        }
+        return session;
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import dev.woori.wooriBank.domain.auth.entity.RefreshToken;
 import dev.woori.wooriBank.domain.auth.jwt.JwtIssuer;
 import dev.woori.wooriBank.domain.auth.port.RefreshTokenPort;
 import dev.woori.wooriBank.domain.auth.entity.Role;
+import dev.woori.wooriBank.domain.util.ValidationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +33,7 @@ public class AuthService {
     private final JwtValidator jwtValidator;
     private final RefreshTokenPort refreshTokenRepository;
     private final AuthStoreRedis redis;
+    private final ValidationUtil validationUtil;
     private static final SecureRandom random = new SecureRandom();
     @Value("${auth.verification.max-attempts}")
     private int maxAttempts;
@@ -77,7 +79,7 @@ public class AuthService {
      */
     public void request(AuthReqDto request){
         // tid 검증
-        AuthSession session = getSessionOrThrow(request.tid());
+        AuthSession session = validationUtil.getSessionOrThrow(request.tid());
 
         // 인증번호 생성 - 랜덤 6자리
         String authCode = String.format("%06d", random.nextInt(1000000));
@@ -87,6 +89,8 @@ public class AuthService {
         session.setBirth(request.birth());
         session.setPhone(request.phone());
         session.setAuthCode(authCode);
+        session.setFailedAttempts(0); // 실패 횟수 초기화
+        session.setVerified(false); // 인증 상태 초기화
         redis.save(request.tid(), session);
 
         // 인증번호를 보내준다 가정함
@@ -101,14 +105,20 @@ public class AuthService {
      */
     public void verify(AuthVerifyReqDto request){
         // tid 검증
-        AuthSession session = getSessionOrThrow(request.tid());
+        AuthSession session = validationUtil.getSessionOrThrow(request.tid());
 
+        // 인증번호 값이 null일 경우
+        if (session.getAuthCode() == null) {
+            throw new CommonException(ErrorCode.INVALID_REQUEST, "만료된 인증번호입니다. 재발송 버튼을 눌러주세요.");
+        }
+
+        // 인증에 실패했을 경우
         if(!request.authCode().equals(session.getAuthCode())){
             // 일정 횟수 이상 실패했을 경우
             if(session.getFailedAttempts() >= maxAttempts){
+                session.setAuthCode(null);
                 session.setFailedAttempts(0);
                 redis.save(request.tid(), session);
-                // TODO: 실패한 이후 세션 삭제...?
                 throw new CommonException(ErrorCode.FORBIDDEN, "인증번호 검증에 실패했습니다. 인증번호를 다시 발급해 주세요.");
             }
             session.setFailedAttempts(session.getFailedAttempts() + 1);
@@ -118,6 +128,29 @@ public class AuthService {
 
         // 인증에 성공하면 verified 상태로 전환
         session.setVerified(true);
+        redis.save(request.tid(), session);
+    }
+
+    /**
+     * 인증번호 재발급 api
+     * @param request tid
+     */
+    public void resendAuthCode(AuthCodeRefreshReqDto request){
+        AuthSession session = validationUtil.getSessionOrThrow(request.tid());
+
+        // 재발급 시도가 너무 많을 경우
+        if(session.getResendAttempts() >= maxAttempts){
+            redis.delete(request.tid()); // 세션 삭제
+            throw new CommonException(ErrorCode.FORBIDDEN,
+                    "재발송 횟수를 초과했습니다. 처음부터 다시 시도해주세요.");
+        }
+
+        // 새로운 인증번호 발급
+        String newCode = String.format("%06d", random.nextInt(1000000));
+        session.setAuthCode(newCode);
+        session.setFailedAttempts(0);
+        session.setResendAttempts(session.getResendAttempts() + 1);
+
         redis.save(request.tid(), session);
     }
 
@@ -143,14 +176,5 @@ public class AuthService {
         refreshTokenRepository.save(token);
 
         return new TokenResDto(accessToken, refreshToken);
-    }
-
-    private AuthSession getSessionOrThrow(String tid) {
-        AuthSession session = redis.get(tid);
-        if (session == null) {
-            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND,
-                    "세션이 만료되었습니다. 처음부터 다시 시작해주세요.");
-        }
-        return session;
     }
 }

--- a/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriBank/domain/auth/service/AuthService.java
@@ -81,15 +81,12 @@ public class AuthService {
         // tid 검증
         AuthSession session = validationUtil.getSessionOrThrow(request.tid());
 
-        // 인증번호 생성 - 랜덤 6자리
-        String authCode = String.format("%06d", random.nextInt(1000000));
-
-        // 세션에 임시저장
+        // 세션에 개인정보 임시저장
         session.setName(request.name());
         session.setBirth(request.birth());
         session.setPhone(request.phone());
-        session.setAuthCode(authCode);
 
+        // 인증번호 발급
         issueNewAuthCode(session);
     }
 

--- a/src/main/java/dev/woori/wooriBank/domain/util/ValidationUtil.java
+++ b/src/main/java/dev/woori/wooriBank/domain/util/ValidationUtil.java
@@ -1,0 +1,23 @@
+package dev.woori.wooriBank.domain.util;
+
+import dev.woori.wooriBank.config.exception.CommonException;
+import dev.woori.wooriBank.config.exception.ErrorCode;
+import dev.woori.wooriBank.domain.auth.entity.AuthSession;
+import dev.woori.wooriBank.domain.auth.entity.AuthStoreRedis;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ValidationUtil {
+    private final AuthStoreRedis redis;
+
+    public AuthSession getSessionOrThrow(String tid) {
+        AuthSession session = redis.get(tid);
+        if (session == null) {
+            throw new CommonException(ErrorCode.ENTITY_NOT_FOUND,
+                    "세션이 만료되었습니다. 처음부터 다시 시작해주세요.");
+        }
+        return session;
+    }
+}


### PR DESCRIPTION
## ✅ 연관된 이슈
#11 

## 📝 작업 내용
- access token return -> 사용자의 client id를 토대로 tid를 발급해 주는 로직으로 변경
- 본인인증 로직을 jwt가 아닌 tid 기반으로 진행하도록 변경
- 계좌번호 응답 또한 tid를 통해 응답해 주는 것으로 변경

## 🖼️ 스크린샷 (선택)
